### PR TITLE
feat: add autoreload and debug from config and app init

### DIFF
--- a/tests/plugins/test_app.py
+++ b/tests/plugins/test_app.py
@@ -17,7 +17,8 @@ class AppPluginsTests(unittest.TestCase):
         assert instance.host == "http://localhost" and \
             instance.port == 7080 and \
             instance.debug == False and \
-            instance.name == "app"
+            instance.name == "app" and \
+            instance.autoreload == True
 
     def test_settings_default(self):
         class DummyApplication:
@@ -29,5 +30,6 @@ class AppPluginsTests(unittest.TestCase):
 
         assert instance.host == "http://localhost" and \
             instance.port == 8000 and \
-            instance.debug == True and \
-            instance.name == "Torn App"
+            instance.debug == False and \
+            instance.name == "Torn App" and \
+            instance.autoreload == False

--- a/tests/test_utils/Config/config.yml
+++ b/tests/test_utils/Config/config.yml
@@ -5,4 +5,4 @@ web:
   port: 7080
 
 debug: False
-devmode: dev
+autoreload: True

--- a/torn/api/app.py
+++ b/torn/api/app.py
@@ -23,9 +23,11 @@ class Application:
 
 
     # method to execute the application
-    def run(self, routes, autoreload=True):
+    def run(self, routes, **settings):
         try:
-            application = tornado.web.Application(autoreload=autoreload)
+            autoreload = settings.get('autoreload', self.autoreload)
+            debug = settings.get('debug', self.debug)
+            application = tornado.web.Application(autoreload=autoreload, debug=debug)
             router = torn.api.route.Router(application, routes)
             http_server = tornado.httpserver.HTTPServer(router)
             http_server.listen(self.port)

--- a/torn/plugins/app.py
+++ b/torn/plugins/app.py
@@ -14,21 +14,18 @@ def settings(instance):
     instance.name = "Torn App"
     instance.port = 8000
     instance.host = "http://localhost"
-    instance.debug = True
+    instance.debug = False
+    instance.autoreload = False
     try:
         with open(instance.root_dir + '/Config/config.yml') as config:
             config = yaml.safe_load(config)
 
             # read from config values
-            if 'name' in config:
-                instance.name = config['name']
-            if 'web' in config:
-                if 'port' in config['web']:
-                    instance.port = config['web']['port']
-                if 'host' in config['web']:
-                    instance.host = config['web']['host']
-            if 'debug' in config:
-                instance.debug = config['debug']
+            instance.name = config.get('name', instance.name)
+            instance.port = config.get('web', {}).get('port', instance.port)
+            instance.host = config.get('web', {}).get('host', instance.host)
+            instance.debug = config.get('debug', instance.debug)
+            instance.autoreload = config.get('autoreload', instance.autoreload)
     except Exception as e:
         print("Error in reading from config file / maybe missing")
     return instance


### PR DESCRIPTION
Now user can define `autoreload` and `debug` mode in two ways.
1. define in `app.py` while initialising app 
   for example:
```python
app = Application()
app.run(routes = Routes.web.route, autoreload=True, debug=True)
```
2. Else in config.yml file
```yml
autoreload: True
debug: True
```

Application initialisation will be given priority if defined.